### PR TITLE
fixed formatting of integers to allow for leading 0's

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,5 +76,5 @@ func main() {
 	pwd := oneTimePassword(key, toBytes(epochSeconds/30))
 
 	secondsRemaining := 30 - (epochSeconds % 30)
-	fmt.Printf("%d (%d second(s) remaining)\n", pwd, secondsRemaining)
+	fmt.Printf("%06d (%d second(s) remaining)\n", pwd, secondsRemaining)
 }


### PR DESCRIPTION
I know I shouldn't be using this, but it looked interesting and noticed a minor issue with int formatting when you have leading 0's always.
